### PR TITLE
fix: search dedup, doc title resolution, FTS5 wildcard

### DIFF
--- a/src/tools/build-legal-stance.ts
+++ b/src/tools/build-legal-stance.ts
@@ -3,7 +3,8 @@
  */
 
 import type { Database } from '@ansvar/mcp-sqlite';
-import { buildFtsQueryVariants } from '../utils/fts-query.js';
+import { buildFtsQueryVariants, buildLikePattern, sanitizeFtsInput } from '../utils/fts-query.js';
+import { resolveExistingStatuteId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 
 export interface BuildLegalStanceInput {
@@ -35,58 +36,150 @@ const MAX_LIMIT = 20;
 
 export async function buildLegalStance(
   db: Database,
-  input: BuildLegalStanceInput
+  input: BuildLegalStanceInput,
 ): Promise<ToolResponse<LegalStanceResult>> {
   if (!input.query || input.query.trim().length === 0) {
     return {
       results: { query: '', provisions: [], total_citations: 0 },
-      _metadata: generateResponseMetadata(db)
+      _metadata: generateResponseMetadata(db),
     };
   }
 
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
-  const queryVariants = buildFtsQueryVariants(input.query);
+  const fetchLimit = limit * 2;
+  const queryVariants = buildFtsQueryVariants(sanitizeFtsInput(input.query));
 
-  let provSql = `
-    SELECT
-      lp.document_id,
-      ld.title as document_title,
-      lp.provision_ref,
-      lp.title,
-      snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
-      bm25(provisions_fts) as relevance
-    FROM provisions_fts
-    JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
-    JOIN legal_documents ld ON ld.id = lp.document_id
-    WHERE provisions_fts MATCH ?
-  `;
-
-  const provParams: (string | number)[] = [];
-
+  // Resolve document_id from title if provided
+  let resolvedDocId: string | undefined;
   if (input.document_id) {
-    provSql += ` AND lp.document_id = ?`;
-    provParams.push(input.document_id);
+    const resolved = resolveExistingStatuteId(db, input.document_id);
+    resolvedDocId = resolved ?? undefined;
+    if (!resolved) {
+      return {
+        results: { query: input.query, provisions: [], total_citations: 0 },
+        _metadata: {
+          ...generateResponseMetadata(db),
+          note: `No document found matching "${input.document_id}"`,
+        },
+      };
+    }
   }
 
-  provSql += ` ORDER BY relevance LIMIT ?`;
-  provParams.push(limit);
+  let queryStrategy = 'none';
+  for (const ftsQuery of queryVariants) {
+    let sql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.title,
+        snippet(provisions_fts, 0, '>>>', '<<<', '...', 48) as snippet,
+        bm25(provisions_fts) as relevance
+      FROM provisions_fts
+      JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE provisions_fts MATCH ?
+    `;
+    const params: (string | number)[] = [ftsQuery];
 
-  const runProvisionQuery = (ftsQuery: string): ProvisionHit[] => {
-    const bound = [ftsQuery, ...provParams];
-    return db.prepare(provSql).all(...bound) as ProvisionHit[];
-  };
+    if (resolvedDocId) {
+      sql += ' AND lp.document_id = ?';
+      params.push(resolvedDocId);
+    }
 
-  let provisions = runProvisionQuery(queryVariants.primary);
-  if (provisions.length === 0 && queryVariants.fallback) {
-    provisions = runProvisionQuery(queryVariants.fallback);
+    sql += ' ORDER BY relevance LIMIT ?';
+    params.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(sql).all(...params) as ProvisionHit[];
+      if (rows.length > 0) {
+        queryStrategy = ftsQuery === queryVariants[0] ? 'exact' : 'fallback';
+        const deduped = deduplicateResults(rows, limit);
+        return {
+          results: {
+            query: input.query,
+            provisions: deduped,
+            total_citations: deduped.length,
+          },
+          _metadata: {
+            ...generateResponseMetadata(db),
+            ...(queryStrategy === 'fallback' ? { query_strategy: 'broadened' } : {}),
+          },
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  // LIKE fallback — final tier when FTS5 returns no results
+  {
+    const likePattern = buildLikePattern(sanitizeFtsInput(input.query));
+    let likeSql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.title,
+        substr(lp.content, 1, 300) as snippet,
+        0 as relevance
+      FROM legal_provisions lp
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE lp.content LIKE ?
+    `;
+    const likeParams: (string | number)[] = [likePattern];
+
+    if (resolvedDocId) {
+      likeSql += ' AND lp.document_id = ?';
+      likeParams.push(resolvedDocId);
+    }
+
+    likeSql += ' LIMIT ?';
+    likeParams.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(likeSql).all(...likeParams) as ProvisionHit[];
+      if (rows.length > 0) {
+        const deduped = deduplicateResults(rows, limit);
+        return {
+          results: {
+            query: input.query,
+            provisions: deduped,
+            total_citations: deduped.length,
+          },
+          _metadata: {
+            ...generateResponseMetadata(db),
+            query_strategy: 'like_fallback',
+          },
+        };
+      }
+    } catch {
+      // LIKE query failed
+    }
   }
 
   return {
-    results: {
-      query: input.query,
-      provisions,
-      total_citations: provisions.length,
-    },
-    _metadata: generateResponseMetadata(db)
+    results: { query: input.query, provisions: [], total_citations: 0 },
+    _metadata: generateResponseMetadata(db),
   };
+}
+
+/**
+ * Deduplicate results by document_title + provision_ref.
+ * Duplicate document IDs (numeric vs slug) cause the same provision to appear twice.
+ */
+function deduplicateResults(
+  rows: ProvisionHit[],
+  limit: number,
+): ProvisionHit[] {
+  const seen = new Set<string>();
+  const deduped: ProvisionHit[] = [];
+  for (const row of rows) {
+    const key = `${row.document_title}::${row.provision_ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+    if (deduped.length >= limit) break;
+  }
+  return deduped;
 }

--- a/src/tools/search-legislation.ts
+++ b/src/tools/search-legislation.ts
@@ -3,8 +3,9 @@
  */
 
 import type { Database } from '@ansvar/mcp-sqlite';
-import { buildFtsQueryVariants } from '../utils/fts-query.js';
+import { buildFtsQueryVariants, buildLikePattern, sanitizeFtsInput } from '../utils/fts-query.js';
 import { normalizeAsOfDate } from '../utils/as-of-date.js';
+import { resolveExistingStatuteId } from '../utils/statute-id.js';
 import { generateResponseMetadata, type ToolResponse } from '../utils/metadata.js';
 
 export interface SearchLegislationInput {
@@ -31,63 +32,155 @@ const MAX_LIMIT = 50;
 
 export async function searchLegislation(
   db: Database,
-  input: SearchLegislationInput
+  input: SearchLegislationInput,
 ): Promise<ToolResponse<SearchLegislationResult[]>> {
   if (!input.query || input.query.trim().length === 0) {
-    return {
-      results: [],
-      _metadata: generateResponseMetadata(db)
-    };
+    return { results: [], _metadata: generateResponseMetadata(db) };
   }
 
   const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
-  const queryVariants = buildFtsQueryVariants(input.query);
+  // Fetch extra rows to account for deduplication
+  const fetchLimit = limit * 2;
+  const queryVariants = buildFtsQueryVariants(sanitizeFtsInput(input.query));
+
   // Validate as_of_date if provided (throws on invalid format)
   if (input.as_of_date) normalizeAsOfDate(input.as_of_date);
 
-  let sql = `
-    SELECT
-      lp.document_id,
-      ld.title as document_title,
-      lp.provision_ref,
-      lp.chapter,
-      lp.section,
-      lp.title,
-      snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
-      bm25(provisions_fts) as relevance
-    FROM provisions_fts
-    JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
-    JOIN legal_documents ld ON ld.id = lp.document_id
-    WHERE provisions_fts MATCH ?
-  `;
-
-  const params: (string | number)[] = [];
-
+  // Resolve document_id from title if provided (same resolution as get_provision)
+  let resolvedDocId: string | undefined;
   if (input.document_id) {
-    sql += ` AND lp.document_id = ?`;
-    params.push(input.document_id);
+    const resolved = resolveExistingStatuteId(db, input.document_id);
+    resolvedDocId = resolved ?? undefined;
+    if (!resolved) {
+      return {
+        results: [],
+        _metadata: {
+          ...generateResponseMetadata(db),
+          note: `No document found matching "${input.document_id}"`,
+        },
+      };
+    }
   }
 
-  if (input.status) {
-    sql += ` AND ld.status = ?`;
-    params.push(input.status);
+  let queryStrategy = 'none';
+  for (const ftsQuery of queryVariants) {
+    let sql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.chapter,
+        lp.section,
+        lp.title,
+        snippet(provisions_fts, 0, '>>>', '<<<', '...', 32) as snippet,
+        bm25(provisions_fts) as relevance
+      FROM provisions_fts
+      JOIN legal_provisions lp ON lp.id = provisions_fts.rowid
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE provisions_fts MATCH ?
+    `;
+    const params: (string | number)[] = [ftsQuery];
+
+    if (resolvedDocId) {
+      sql += ' AND lp.document_id = ?';
+      params.push(resolvedDocId);
+    }
+
+    if (input.status) {
+      sql += ' AND ld.status = ?';
+      params.push(input.status);
+    }
+
+    sql += ' ORDER BY relevance LIMIT ?';
+    params.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(sql).all(...params) as SearchLegislationResult[];
+      if (rows.length > 0) {
+        queryStrategy = ftsQuery === queryVariants[0] ? 'exact' : 'fallback';
+        const deduped = deduplicateResults(rows, limit);
+        return {
+          results: deduped,
+          _metadata: {
+            ...generateResponseMetadata(db),
+            ...(queryStrategy === 'fallback' ? { query_strategy: 'broadened' } : {}),
+          },
+        };
+      }
+    } catch {
+      // FTS query syntax error — try next variant
+      continue;
+    }
   }
 
-  sql += ` ORDER BY relevance LIMIT ?`;
-  params.push(limit);
+  // LIKE fallback — final tier when FTS5 returns no results
+  {
+    const likePattern = buildLikePattern(sanitizeFtsInput(input.query));
+    let likeSql = `
+      SELECT
+        lp.document_id,
+        ld.title as document_title,
+        lp.provision_ref,
+        lp.chapter,
+        lp.section,
+        lp.title,
+        substr(lp.content, 1, 200) as snippet,
+        0 as relevance
+      FROM legal_provisions lp
+      JOIN legal_documents ld ON ld.id = lp.document_id
+      WHERE lp.content LIKE ?
+    `;
+    const likeParams: (string | number)[] = [likePattern];
 
-  const runQuery = (ftsQuery: string): SearchLegislationResult[] => {
-    const bound = [ftsQuery, ...params];
-    return db.prepare(sql).all(...bound) as SearchLegislationResult[];
-  };
+    if (resolvedDocId) {
+      likeSql += ' AND lp.document_id = ?';
+      likeParams.push(resolvedDocId);
+    }
 
-  const primaryResults = runQuery(queryVariants.primary);
-  const results = (primaryResults.length > 0 || !queryVariants.fallback)
-    ? primaryResults
-    : runQuery(queryVariants.fallback);
+    if (input.status) {
+      likeSql += ' AND ld.status = ?';
+      likeParams.push(input.status);
+    }
 
-  return {
-    results,
-    _metadata: generateResponseMetadata(db)
-  };
+    likeSql += ' LIMIT ?';
+    likeParams.push(fetchLimit);
+
+    try {
+      const rows = db.prepare(likeSql).all(...likeParams) as SearchLegislationResult[];
+      if (rows.length > 0) {
+        return {
+          results: deduplicateResults(rows, limit),
+          _metadata: {
+            ...generateResponseMetadata(db),
+            query_strategy: 'like_fallback',
+          },
+        };
+      }
+    } catch {
+      // LIKE query failed
+    }
+  }
+
+  return { results: [], _metadata: generateResponseMetadata(db) };
+}
+
+/**
+ * Deduplicate search results by document_title + provision_ref.
+ * Duplicate document IDs (numeric vs slug) cause the same provision to appear twice.
+ * Keeps the first (highest-ranked) occurrence.
+ */
+function deduplicateResults(
+  rows: SearchLegislationResult[],
+  limit: number,
+): SearchLegislationResult[] {
+  const seen = new Set<string>();
+  const deduped: SearchLegislationResult[] = [];
+  for (const row of rows) {
+    const key = `${row.document_title}::${row.provision_ref}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(row);
+    if (deduped.length >= limit) break;
+  }
+  return deduped;
 }

--- a/src/utils/fts-query.ts
+++ b/src/utils/fts-query.ts
@@ -1,59 +1,119 @@
 /**
- * FTS5 query builder for French Law MCP.
+ * FTS5 query helpers for French Law MCP.
  *
- * Sanitizes user input to prevent FTS5 syntax errors while preserving
- * intentional boolean operators (AND, OR, NOT) and phrase searches.
+ * Handles query sanitization and variant generation for SQLite FTS5.
  */
 
-const EXPLICIT_FTS_SYNTAX = /["""]|(\bAND\b)|(\bOR\b)|(\bNOT\b)|\*$/;
+const FTS5_BOOLEAN_OPS = /\b(AND|OR|NOT)\b/;
 
 /**
- * Characters that have special meaning in FTS5 and must be stripped
- * from tokens to prevent syntax errors. FTS5 operators include:
- * - ^ (column filter prefix)
- * - : (column filter)
- * - ( ) (grouping)
- * - + (prefix for NEAR queries)
- * - { } (NEAR distance)
- * - . (column path separator)
+ * Detect whether input contains FTS5 boolean operators.
  */
-const FTS5_SPECIAL_CHARS = /[():{}^+.]/g;
-
-export interface FtsQueryVariants {
-  primary: string;
-  fallback?: string;
+export function hasBooleanOperators(input: string): boolean {
+  return FTS5_BOOLEAN_OPS.test(input);
 }
 
 /**
- * Sanitize a raw user input string for safe use in FTS5 MATCH.
- * Removes characters that could cause FTS5 syntax errors.
+ * Sanitize user input for safe FTS5 queries.
+ * Preserves boolean operators (AND, OR, NOT) when detected.
  */
-export function sanitizeFtsInput(raw: string): string {
-  return raw.replace(FTS5_SPECIAL_CHARS, ' ').replace(/\s+/g, ' ').trim();
+export function sanitizeFtsInput(input: string): string {
+  if (hasBooleanOperators(input)) {
+    // Preserve boolean structure: only strip dangerous chars, keep quotes and parens
+    return input.replace(/[{}[\]^~*:]/g, ' ').replace(/\s+/g, ' ').trim();
+  }
+  // Preserve trailing * on words (FTS5 prefix search) but strip other special chars
+  return input
+    .replace(/['"(){}[\]^~:]/g, ' ')
+    .replace(/\*(?!\s|$)/g, ' ')    // strip * unless at end of word
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
-export function buildFtsQueryVariants(query: string): FtsQueryVariants {
-  const trimmed = query.trim();
+/**
+ * Truncate common French/English suffixes for stemming fallback.
+ * Returns stem + "*" ready string, or null if no stemming possible.
+ */
+function stemWord(word: string): string | null {
+  if (word.length < 5) return null;
+  const lower = word.toLowerCase();
+  for (const suffix of [
+    'tion', 'ment', 'eurs', 'euse', 'ance', 'ence', 'ique', 'ible', 'able',
+    'ies', 'ing', 'ers', 'ness',
+    'ous', 'ive', 'ed', 'es', 'er', 'ly', 's',
+  ]) {
+    if (lower.endsWith(suffix) && lower.length - suffix.length >= 3) {
+      return lower.slice(0, -suffix.length);
+    }
+  }
+  return null;
+}
 
-  if (EXPLICIT_FTS_SYNTAX.test(trimmed)) {
-    // User is using explicit FTS5 syntax — sanitize only dangerous chars,
-    // preserve AND/OR/NOT and quoted phrases
-    // Reuse FTS5_SPECIAL_CHARS constant (keep in sync with sanitizeFtsInput)
-    const sanitized = sanitizeFtsInput(trimmed);
-    return { primary: sanitized || trimmed };
+/**
+ * Build FTS5 query variants for a search term.
+ * Returns variants in order of specificity (most specific first):
+ * 1. Exact phrase match
+ * 2. All terms required (AND)
+ * 3. Prefix AND (last term gets prefix wildcard)
+ * 4. Stemmed prefix (suffix-truncated + wildcard)
+ * 5. Any term matches (OR) — broad fallback
+ *
+ * When boolean operators are detected, passes query through as-is.
+ */
+export function buildFtsQueryVariants(sanitized: string): string[] {
+  if (!sanitized || sanitized.trim().length === 0) {
+    return [];
   }
 
-  const tokens = sanitizeFtsInput(trimmed)
-    .split(/\s+/)
-    .filter(t => t.length > 0)
-    .map(t => t.replace(/[^\w\s\u00C0-\u024F-]/g, ''));
-
-  if (tokens.length === 0) {
-    return { primary: trimmed };
+  // Boolean passthrough — user knows what they want
+  if (hasBooleanOperators(sanitized)) {
+    return [sanitized];
   }
 
-  const primary = tokens.map(t => `"${t}"*`).join(' ');
-  const fallback = tokens.map(t => `${t}*`).join(' OR ');
+  const terms = sanitized.split(/\s+/).filter(t => t.length > 0);
+  if (terms.length === 0) return [];
 
-  return { primary, fallback };
+  const variants: string[] = [];
+
+  if (terms.length > 1) {
+    // Exact phrase
+    variants.push(`"${terms.join(' ')}"`);
+    // AND query
+    variants.push(terms.join(' AND '));
+    // Prefix AND on last term
+    variants.push([...terms.slice(0, -1), `${terms[terms.length - 1]}*`].join(' AND '));
+  } else {
+    // Single term
+    variants.push(terms[0]);
+    if (terms[0].length >= 3) {
+      variants.push(`${terms[0]}*`);
+    }
+  }
+
+  // Stemmed variant — truncate suffixes + wildcard
+  const stemmedTerms = terms.map(t => {
+    const stem = stemWord(t);
+    return stem ? `${stem}*` : t;
+  });
+  if (stemmedTerms.some((s, i) => s !== terms[i])) {
+    variants.push(stemmedTerms.join(' AND '));
+  }
+
+  // OR fallback — any term matches (broadest)
+  if (terms.length > 1) {
+    variants.push(terms.join(' OR '));
+  }
+
+  return variants;
+}
+
+/**
+ * Build a SQL LIKE pattern from search terms.
+ * Used as a final fallback when FTS5 returns no results.
+ * Example: "penalty offence" -> "%penalty%offence%"
+ */
+export function buildLikePattern(query: string): string {
+  const terms = query.trim().split(/\s+/).filter(t => t.length > 0);
+  if (terms.length === 0) return '%';
+  return `%${terms.join('%')}%`;
 }

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -8,6 +8,8 @@ export interface ResponseMetadata {
   data_freshness: string;
   disclaimer: string;
   source_authority: string;
+  note?: string;
+  query_strategy?: string;
 }
 
 export interface ToolResponse<T> {


### PR DESCRIPTION
## Summary
- Deduplicate search results in `search_legislation` and `build_legal_stance` to eliminate duplicate provisions from numeric/slug document ID overlap
- Resolve document titles in search/stance using `resolveExistingStatuteId` so `document_id` accepts human-readable titles
- Refactor `fts-query.ts` to return ranked string[] variants with stemming and LIKE fallback
- Preserve trailing `*` in `sanitizeFtsInput` for FTS5 prefix queries (e.g. `control*`)
- Add `query_strategy: 'broadened'` to `_metadata` when falling back to broader FTS variants
- Add `note` and `query_strategy` optional fields to `ResponseMetadata` interface

## Test plan
- [x] `npm run lint` passes (tsc --noEmit)
- [x] `npm test` passes (1 pre-existing failure in mcp-output.test.ts unrelated to changes)
- [x] HTTP transport: dedup verified (0 duplicates)
- [x] HTTP transport: wildcard prefix `control*` matches controle/controleur/controleurs
- [x] HTTP transport: doc ID resolution with "Code pénal" title works
- [x] HTTP transport: broadened fallback detected in metadata
- [x] HTTP transport: get_provision regression OK

Generated with [Claude Code](https://claude.com/claude-code)