### PR TITLE
fix: accept article param in get_provision for fleet audit compatibility

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -11,6 +11,7 @@ export interface GetProvisionInput {
   part?: string;
   chapter?: string;
   section?: string;
+  article?: string;
   provision_ref?: string;
 }
 
@@ -46,7 +47,7 @@ export async function getProvision(
 
   const resolvedDocumentId = resolveExistingStatuteId(db, input.document_id) ?? input.document_id;
 
-  const provisionRef = input.provision_ref ?? input.section;
+  const provisionRef = input.provision_ref ?? input.section ?? input.article;
 
   // If no specific provision, return provisions for the document (capped to prevent context overflow)
   const MAX_PROVISIONS = 200;


### PR DESCRIPTION
## Summary

- Adds `article?: string` to `GetProvisionInput` interface in `get-provision.ts`
- Changes provision ref resolution from `input.provision_ref ?? input.section` to `input.provision_ref ?? input.section ?? input.article`

Fleet audit sends `{"document_id": "...", "article": "1"}` — the tool was silently ignoring `article`, returning empty content instead of the requested provision.

## Test plan
- [x] `tsc --noEmit` passes locally
- [x] Squash-merged to `dev` via PR #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)