### PR TITLE
fix(deps): npm audit fix for hono/path-to-regexp CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@vercel/build-utils": {
-      "version": "13.14.0",
-      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.14.0.tgz",
-      "integrity": "sha512-mEYh+f+sNngEOJKLTTzoyPMse5A3bQNt0uIRq/jfl/h12ukWhrpHDmXdY6k6x3WsEXr7hrcN+2jT0VdvOBgACw==",
+      "version": "13.14.2",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.14.2.tgz",
+      "integrity": "sha512-L1wHzpSXVcaXji5+ylNV5yTpAKf/t6qEGNOdFrMSAqSWlcYtL9rrY1OFbqN+5gIAWXjdCqnkmBRVp1lk20uwdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1314,9 +1314,9 @@
       }
     },
     "node_modules/@vercel/node": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.2.tgz",
-      "integrity": "sha512-uX4l/f/0eu6ktDdUobHxUm3jkI85Ptbp08yMYFYJo9PAmsYJ5jJoU3eOS47XgkIXmQHGC+14UP1NN7Jh1bTkTA==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.7.4.tgz",
+      "integrity": "sha512-pSU3hl7fSPPD/0W0RzwbogFTiTUT+LDIu0+qOdd/ZZAPQauefs09KQiRZGkt3oPmKnAWTvoQv/Ea4dWZcE9ijQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1324,7 +1324,7 @@
         "@edge-runtime/primitives": "4.1.0",
         "@edge-runtime/vm": "3.2.0",
         "@types/node": "20.11.0",
-        "@vercel/build-utils": "13.14.0",
+        "@vercel/build-utils": "13.14.2",
         "@vercel/error-utils": "2.0.3",
         "@vercel/nft": "1.5.0",
         "@vercel/static-config": "3.2.0",


### PR DESCRIPTION
Patches transitive CVEs flagged by CI npm audit gate. Auto-generated via `npm audit fix --package-lock-only`. Before: 0 high/critical / After: 0. 🤖 Generated with [Claude Code](https://claude.com/claude-code)