### PR TITLE
fix(dockerfile): clean stale sqlite .lock dir on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,10 @@ RUN addgroup -S nodejs && adduser -S nodejs -G nodejs \
 USER nodejs
 
 ENV NODE_ENV=production
-CMD ["node", "dist/http-server.js"]
+
+# Clean stale node-sqlite3-wasm lock dirs left over from a SIGKILL'd prior
+# run. The library locks via mkdir(<dbpath>.lock); on crash the dir is not
+# removed, and the next start fails with "database is locked" forever.
+# The bind mount targets the database.db file, so the parent /app/data dir
+# is in the container's writable layer and safe to clean.
+CMD ["sh", "-c", "rm -rf /app/data/*.lock 2>/dev/null; exec node dist/http-server.js"]


### PR DESCRIPTION
## Why — production crash loop

`law-french` is in a tight crash loop on prod (2,000+ restarts since 2026-05-05). Same fix is going to `ecuadorian-law-mcp` and `polish-law-mcp` in parallel PRs — all three have identical symptom and root cause.

### Stack trace

```
Fatal: SQLite3Error: database is locked
    at Database.prepare (.../node-sqlite3-wasm.js:1:5223)
    at Database.prepare (.../@ansvar/mcp-sqlite/dist/index.js:101:47)
    at detectCapabilities (file:///app/dist/capabilities.js:13:31)
```

### Root cause

`node-sqlite3-wasm` implements file locking by `fs.mkdirSync(<dbpath>.lock)` directly (it's not the standard SQLite POSIX advisory lock — it's a userspace VFS shim). When a process is SIGKILL'd before `_nodejsUnlock` runs `rmdirSync`, the `.lock` directory survives. On next start the new process tries `mkdirSync` and gets `EEXIST`, which the VFS maps to `SQLITE_BUSY` → "database is locked", and the cycle repeats forever.

Confirmed by `docker cp law-french:/app/data` showing:

```
drwxr-xr-x  2 deploy deploy       4096 May  5 04:01 database.db.lock   ← stale, never cleaned
-rw-r--r--  1 deploy deploy 1194541056 Mar 30 06:26 database.db
```

The bind mount is `/data/premium-dbs/french-law/database-premium.db → /app/data/database.db:ro` (the FILE, not the directory). So the parent `/app/data` is in the container's writable overlay layer and the stale `.lock` dir survives every container restart.

### Verification

- Fresh container with the same image+mount+env starts cleanly (rules out image / DB / mount as root cause).
- Simulating `mkdir /app/data/database.db.lock` reproduces the crash exactly.
- With this CMD change applied (verified on prod inside an ephemeral container):
  ```
  BEFORE:  database.db.lock  (stale)
  AFTER:   (gone)
  [french-law-mcp] Database: /app/data/database.db
  [french-law-mcp] Tier: premium, Capabilities: core_legislation, eu_references, case_law, preparatory_works
  french-law-mcp v2.0.0 HTTP server listening on port 3000
  ```

## What this PR does

Replace the bare `CMD ["node", "dist/http-server.js"]` with a shell-form CMD that runs `rm -rf /app/data/*.lock` before exec'ing node. The bind mount targets the `database.db` file, so `/app/data` itself is writable container-overlay storage and safe to clean. The `*.lock` glob doesn't match `database.db`, so the data file is untouched.

## Follow-ups (not in this PR)

1. **Immediate prod recovery:** the user needs to run `docker compose up -d --force-recreate law-french law-ecuadorian law-polish` on the prod host to wipe the stale `.lock` dirs from the writable layer NOW (otherwise we wait for Watchtower's hourly poll after this PR + `dev → main` lands).
2. **Generator script:** `rollout-http-transport.sh` in `Ansvar-Architecture-Documentation` produces this Dockerfile from a template — needs the same patch so future MCPs inherit the fix.
3. **Upstream:** `@ansvar/mcp-sqlite` should expose a `cleanStaleLocks` option, or `node-sqlite3-wasm`'s VFS shouldn't use mkdir-based locking on `SQLITE_OPEN_READONLY` connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)