### PR TITLE
fix(ci+about): provision DB in CI; wrap about response in {results, _metadata} envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Download bundled database
+        run: bash scripts/download-db.sh
+
       - name: Build
         run: npm run build
 
@@ -66,6 +69,7 @@ jobs:
           cache: npm
 
       - run: npm ci --ignore-scripts
+      - run: bash scripts/download-db.sh
       - run: npm run build
       - run: npm run test:contract
 
@@ -83,5 +87,6 @@ jobs:
           cache: npm
 
       - run: npm ci --ignore-scripts
+      - run: bash scripts/download-db.sh
       - run: npm run build
       - run: CONTRACT_MODE=nightly npm run test:contract

--- a/src/tools/about.ts
+++ b/src/tools/about.ts
@@ -1,8 +1,13 @@
 /**
  * about — Server metadata, dataset statistics, and provenance.
+ *
+ * Returns the fleet envelope shape: { results: { server, dataset, provenance, security }, _metadata }.
+ * Asserted by tests/integration/mcp-output.test.ts ('all tools return parseable JSON
+ * with results and _metadata envelopes').
  */
 
 import type Database from '@ansvar/mcp-sqlite';
+import { detectCapabilities, readDbMetadata } from '../capabilities.js';
 import { generateResponseMetadata } from '../utils/metadata.js';
 
 export interface AboutContext {
@@ -20,43 +25,54 @@ function safeCount(db: InstanceType<typeof Database>, sql: string): number {
   }
 }
 
-export function getAbout(db: InstanceType<typeof Database>, context: AboutContext) {
-
-  const euRefs = safeCount(db, 'SELECT COUNT(*) as count FROM eu_references');
-
-  const stats: Record<string, number> = {
-    documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
-    provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
-    definitions: safeCount(db, 'SELECT COUNT(*) as count FROM definitions'),
-  };
-
-  if (euRefs > 0) {
-    stats.eu_documents = safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents');
-    stats.eu_references = euRefs;
+function safeCapabilities(db: InstanceType<typeof Database>): string[] {
+  try {
+    return [...detectCapabilities(db)];
+  } catch {
+    return [];
   }
+}
+
+export function getAbout(db: InstanceType<typeof Database>, context: AboutContext) {
+  const meta = readDbMetadata(db);
 
   return {
-    name: 'French Law MCP',
-    version: context.version,
-    jurisdiction: 'FR',
-    description: 'French Law MCP — legislation via Model Context Protocol',
-    stats,
-    data_sources: [
-      {
-        name: 'Legifrance',
-        url: 'https://www.legifrance.gouv.fr',
-        authority: 'Direction de l\'information legale et administrative',
+    results: {
+      server: {
+        name: 'French Law MCP',
+        version: context.version,
+        repository: 'https://github.com/Ansvar-Systems/French-law-mcp',
       },
-    ],
-    freshness: {
-      database_built: context.dbBuilt,
-    },
-    disclaimer:
-      'This is a research tool, not legal advice. Verify critical citations against official sources.',
-    network: {
-      name: 'Ansvar MCP Network',
-      open_law: 'https://ansvar.eu/open-law',
-      directory: 'https://ansvar.ai/mcp',
+      dataset: {
+        jurisdiction: 'France (FR)',
+        languages: ['fr'],
+        counts: {
+          legal_documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
+          legal_provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
+          definitions: safeCount(db, 'SELECT COUNT(*) as count FROM definitions'),
+          eu_documents: safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents'),
+          eu_references: safeCount(db, 'SELECT COUNT(*) as count FROM eu_references'),
+        },
+        fingerprint: context.fingerprint,
+        built_at: context.dbBuilt,
+        tier: meta.tier,
+        schema_version: meta.schema_version,
+        capabilities: safeCapabilities(db),
+      },
+      provenance: {
+        sources: [
+          {
+            name: 'Légifrance',
+            authority: "Direction de l'information légale et administrative (DILA)",
+            url: 'https://www.legifrance.gouv.fr',
+            license: 'Public Domain (Code de la propriété intellectuelle, Art. L111-5)',
+          },
+        ],
+      },
+      security: {
+        access_model: 'read-only',
+        pii: 'none',
+      },
     },
     _metadata: generateResponseMetadata(db),
   };


### PR DESCRIPTION
## Summary

Two fixes for French Law MCP CI failures (#60). The DB-download fix (commit 1) revealed an underlying about-tool envelope-shape issue (commit 2); both bundled here to avoid a stuck red main.

### 1. DB provisioning in CI (`547c0ee`)

`tests/fixtures/db.ts:17` calls `copyFileSync('data/database.db', tempPath)` which ENOENT-fails because no CI job step provisions the bundled database. Adds `bash scripts/download-db.sh` between `npm ci` and `npm run build` in all three CI jobs (`build-and-test`, `contract-tests`, `contract-tests-nightly`). Uses the existing `v2.0.0` release asset (`database.db.gz`, 12 MB) — same pattern Austrian-law-mcp ships green.

### 2. about-tool envelope shape (`ea4a140`)

`tests/integration/mcp-output.test.ts` asserts `{ results, _metadata }` on every tool response. The about tool returned a flat shape (`{name, version, jurisdiction, stats, ...}`) — once commit 1 let CI actually reach this assertion, it failed.

Wrapped the response in the canonical envelope:
- `results.server` — name, version, repository
- `results.dataset` — jurisdiction (`France (FR)`), languages (`['fr']`), counts (legal_documents, legal_provisions, definitions, eu_documents, eu_references), fingerprint, built_at, tier, schema_version, capabilities
- `results.provenance.sources[0]` — Légifrance, DILA, Public Domain (CPI Art. L111-5)
- `results.security` — read-only, no PII
- `_metadata` — generateResponseMetadata(db) → data_freshness, disclaimer, source_authority

Note this differs from Austrian/Belgian (which return `{ server, dataset, provenance, security, _metadata }` flat at top level). French's stricter integration test enforces the `results` envelope; Austrian/Belgian don't have this test. Both flavors satisfy contract test `text_contains` assertions because they're substring checks.

## Why bundled

The two fixes are causally linked: commit 1 exposed the bug that commit 2 fixes. Splitting them would leave main red between merges. Per memory `feedback_validation_tightening_blast_radius.md`, validation-tightening without paired cleanup creates blocked queues — same principle here.

## Local verification

- `npx tsc --noEmit` — clean
- Local vitest can't run the integration test without the DB, so CI validates the about-shape change. Contract tests for French don't reference the about tool.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, rebase #60 onto `main` → unblocks the cleanup PR
- [ ] After merge, dependabot PRs (#56, #58, #62) currently red on the same root cause should rebase clean

## Related

Unblocks #60 (golden-standard cleanup) and the dependabot queue.