### PR TITLE
chore(license): declare FR-Etalab-2.0 reuse basis (statutes NOT statutory-PD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,9 +375,19 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Codes:** DILA / Direction de l'information légale et administrative ([Licence Ouverte](https://www.etalab.gouv.fr/licence-ouverte-open-licence))
-- **Case Law:** Légifrance open data
-- **EU Metadata:** EUR-Lex (EU public domain)
+Upstream legal materials are reused under the **French Open Licence v2.0**
+(Licence Ouverte, Etalab) — Ansvar attribution code `FR-Etalab-2.0`.
+
+- **Statutes & Codes:** DILA / Direction de l'information légale et administrative — published under [Licence Ouverte v2.0](https://www.etalab.gouv.fr/licence-ouverte-open-licence/). Commercial reuse permitted with attribution and licence-notice preservation.
+- **Case Law:** Légifrance open data, same Etalab licence.
+- **EU Metadata:** EUR-Lex (EU public-domain notice).
+
+**Important:** French statutes are NOT in the public domain. France did not
+adopt a statutory-PD carve-out comparable to Germany (UrhG §5) or Spain
+(TRLPI Art. 13). The reuse basis is Etalab's open licence, which requires
+attribution and licence-notice preservation. The Ansvar attribution code
+`FR-Etalab-2.0` is declared in `infrastructure/attribution-licenses.json`
+in the Ansvar architecture-documentation repo.
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -13,8 +13,10 @@ sources:
     last_ingested: '2026-02-16'
     license_or_terms:
       type: 'Licence Ouverte v2.0'
+      ansvar_code: 'FR-Etalab-2.0'
       url: 'https://www.etalab.gouv.fr/licence-ouverte-open-licence/'
-      summary: 'French government open data license, free to use with attribution'
+      url_pattern: '^https?://(?:www\.)?legifrance\.gouv\.fr/.+'
+      summary: 'French Open Licence v2.0 (Etalab) — commercial reuse permitted with attribution. Statutory texts are NOT in public domain under French law; reuse depends on Etalab terms. See infrastructure/attribution-licenses.json FR-Etalab-2.0 in arch-docs.'
     coverage:
       scope: 'All consolidated French codes and laws from LEGI open data'
       limitations: 'Full corpus coverage — all codes and consolidated laws (TNC) from DILA LEGI archive'


### PR DESCRIPTION
## Summary

- Sync `sources.yml` + README to the verified Ansvar attribution catalog (`infrastructure/attribution-licenses.json`, code `FR-Etalab-2.0`).
- README License section now explains the Etalab licence basis and explicitly flags that French statutes are NOT in the public domain (no statutory-PD carve-out like Germany UrhG §5 or Spain TRLPI Art. 13).
- Adds `ansvar_code: 'FR-Etalab-2.0'` and anchored `url_pattern` in sources.yml `license_or_terms`.

## Coverage scope

- IN-SCOPE: Légifrance LEGI corpus (statutes, codes), JADE (caselaw), KALI (collective agreements) — all under Etalab Licence Ouverte v2.0.
- Requirements: attribution + licence-notice preservation on downstream reuse.

## References

- arch-docs audit: `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md`
- arch-docs manifest: `backstage/catalog/fleet-manifests/french-law.json` already declares `license: FR-Etalab-2.0`.

## Test plan

- [ ] CI passes (no code paths changed; license/docs only)
- [ ] Verify README License section renders correctly on GitHub